### PR TITLE
refactor: pass data source and pass to WebFront

### DIFF
--- a/src/main/java/io/surati/gap/commons/utils/pf4j/WebFront.java
+++ b/src/main/java/io/surati/gap/commons/utils/pf4j/WebFront.java
@@ -1,9 +1,37 @@
 package io.surati.gap.commons.utils.pf4j;
 
+import javax.sql.DataSource;
 import org.pf4j.ExtensionPoint;
+import org.takes.facets.auth.Pass;
 import org.takes.facets.fork.Fork;
 
+/**
+ * Web front extension for getting a module pages.
+ *
+ * @since 0.3
+ */
 public interface WebFront extends ExtensionPoint {
 
+    /**
+     * Get pages.
+     *
+     * @return Fork
+     */
     Fork pages();
+
+    /**
+     * Get pages based on sql database.
+     *
+     * @param src Data source
+     * @return Fork
+     */
+    Fork pages(DataSource src);
+
+    /**
+     * Get pages based on a sql database and a pass.
+     * @param src Data source
+     * @param pass Pass
+     * @return Fork
+     */
+    Fork pages(DataSource src, Pass pass);
 }


### PR DESCRIPTION
We noticed that pages are often on data source and pass.
We added some methods to interface WebFront that allow to pass them these parameters.

Resolve: #13