### PR TITLE
feat: introduce ModuleRegistration

### DIFF
--- a/src/main/java/io/surati/gap/commons/utils/pf4j/ModuleRegistration.java
+++ b/src/main/java/io/surati/gap/commons/utils/pf4j/ModuleRegistration.java
@@ -1,0 +1,16 @@
+package io.surati.gap.commons.utils.pf4j;
+
+import org.pf4j.ExtensionPoint;
+
+/**
+ * Extension contract that helps to register some information and metadata on a module.
+ *
+ * @since 0.4
+ */
+public interface ModuleRegistration extends ExtensionPoint {
+
+    /**
+     * Registers.
+     */
+    void register();
+}


### PR DESCRIPTION
This contract helps to define prior operations before starting a module.

Resolve: #19